### PR TITLE
Add another transaction type

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -201,19 +201,27 @@ const Home: NextPage = () => {
   };
 
   const getHederaActions = (): AccountAction[] => {
+    const requestTypeHandlerMap = {
+      [RequestType.CryptoTransfer.toString()]:
+        hederaRpc.testSignAndSendCryptoTransfer,
+      [RequestType.ConsensusSubmitMessage.toString()]:
+        hederaRpc.testSignAndSendTopicSubmitMessage,
+    };
     const onSignAndSendTransaction =
       (requestType: string) => async (chainId: string, address: string) => {
         openRequestModal();
-        console.log("***", { requestType });
-        await hederaRpc.testSignAndSendTransaction(chainId, address);
+        const transactionToExecute = requestTypeHandlerMap[requestType];
+        await transactionToExecute(chainId, address);
       };
-    const requestTypes = [RequestType.CryptoTransfer, RequestType.TokenCreate];
-    const actions: AccountAction[] = requestTypes.map((type) => ({
-      method:
-        DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_SEND_TRANSACTION +
-        `: ${type.toString()}`,
-      callback: onSignAndSendTransaction(type.toString()),
-    }));
+
+    const actions: AccountAction[] = Object.keys(requestTypeHandlerMap).map(
+      (type) => ({
+        method:
+          DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_SEND_TRANSACTION +
+          `: ${type.toString()}`,
+        callback: onSignAndSendTransaction(type.toString()),
+      })
+    );
     return actions;
   };
 


### PR DESCRIPTION
### Summary
Adds `TopicMessageSubmitTransaction` example. Uses the same params builder. Adds a second method to the `hederaRpc` context. Will attempt to refactor to use the same handler, but it's tricky based on how the app was previously configured to use the `_createJsonRpcRequestHandler` factory function

https://github.com/hgraph-io/hedera-walletconnect-dapp/assets/136644362/47bf9aa5-4ab2-499d-812c-76d8ad22ae97

