### PR TITLE
Properly convert tinybars to formatted hbar amount

### DIFF
--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import { AssetData } from "./types";
+import { Hbar, HbarUnit } from "@hashgraph/sdk";
 
 export const rpcProvidersByChainId: Record<number, any> = {
   1: {
@@ -45,10 +46,9 @@ export async function apiGetAccountBalance(
   const namespace = chainId.split(":")[0];
   if (namespace === "hedera") {
     const response = await hederaApi.get(`/accounts/${address}`);
-    const { data } = response;
-    const balance = data.balance.balance;
+    const { balance } = response.data.balance;
     return {
-      balance,
+      balance: Hbar.fromTinybars(balance).to(HbarUnit.Hbar).toFormat(),
       name: "HBAR",
       symbol: "ℏ",
     };


### PR DESCRIPTION
### Summary
Seeing my test account balance in hashscan made me realize that I was not displaying the correct amount for the account balance for hedera. Fixed that using the `Hbar` and `HbarUnit` classes from the sdk.

#### Before
<img width="300" alt="Screenshot 2023-07-12 at 4 32 02 PM" src="https://github.com/hgraph-io/hedera-walletconnect-dapp/assets/136644362/eb6bdddf-6f72-4747-a0cf-5360c42cdf9e">

#### After
<img width="300" alt="Screenshot 2023-07-12 at 4 26 47 PM" src="https://github.com/hgraph-io/hedera-walletconnect-dapp/assets/136644362/9908692b-f9d8-4988-a029-d473d7c388eb">

