### PR TITLE
Dont use sdk to convert balance since it breaks the modal

### DIFF
--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import { AssetData } from "./types";
-import { Hbar, HbarUnit } from "@hashgraph/sdk";
+import { formatTinybarAsHbar } from "./utilities";
 
 export const rpcProvidersByChainId: Record<number, any> = {
   1: {
@@ -48,7 +48,7 @@ export async function apiGetAccountBalance(
     const response = await hederaApi.get(`/accounts/${address}`);
     const { balance } = response.data.balance;
     return {
-      balance: Hbar.fromTinybars(balance).to(HbarUnit.Hbar).toFormat(),
+      balance: formatTinybarAsHbar(balance),
       name: "HBAR",
       symbol: "ℏ",
     };

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -237,3 +237,10 @@ export const getAllChainNamespaces = () => {
 export const getProviderUrl = (chainId: string) => {
   return `https://rpc.walletconnect.com/v1/?chainId=${chainId}&projectId=${process.env.NEXT_PUBLIC_PROJECT_ID}`;
 };
+
+export const formatTinybarAsHbar = (balance: number | string): string => {
+  const numBalance = Number(balance);
+  const balFromTinybars = numBalance / 1e8;
+  const [integer, decimal] = balFromTinybars.toString().split(".");
+  return Number(integer).toLocaleString() + "." + decimal;
+};


### PR DESCRIPTION
### Summary
For some reason, importing the `@hashgraph/sdk` to convert the Hbar balance messed with React import and broke the modals. Instead, we'll just use a custom formatting function for now.