### PR TITLE
Transaction bytes as base64

### DIFF
--- a/src/contexts/JsonRpcContext.tsx
+++ b/src/contexts/JsonRpcContext.tsx
@@ -418,7 +418,7 @@ export function JsonRpcContextProvider({
         const payerAccountId = new AccountId(Number(address.split(".").pop()));
         const transactionId = TransactionId.generate(payerAccountId);
         const transactionAmt = 1000;
-        const receiverAddress = "0.0.14838598"; // hard-coded to my 2nd test account for now
+        const receiverAddress = "0.0.432284"; // hard-coded to my 2nd test account for now
         const memo = `Transfer amount: ${Hbar.fromTinybars(
           transactionAmt
         ).toString()}, from: ${address}, to: ${receiverAddress}`;
@@ -465,7 +465,7 @@ export function JsonRpcContextProvider({
         const transactionId = TransactionId.generate(payerAccountId);
 
         const transaction = new TopicMessageSubmitTransaction()
-          .setTopicId("0.0.15378604") // Topic created for testing this app
+          .setTopicId("0.0.432078") // Topic created for testing this app
           .setMessage(
             `Hello from hedera-walletconnect-dapp at ${new Date().toISOString()}`
           )

--- a/src/helpers/HederaParamsFactory.ts
+++ b/src/helpers/HederaParamsFactory.ts
@@ -9,7 +9,7 @@ import { TypedRequestParams } from "./types";
 export type HederaSignAndSendTransactionParams = {
   transaction: {
     type: string;
-    bytes: Uint8Array;
+    bytes: string;
   };
 };
 
@@ -26,7 +26,7 @@ export class HederaParamsFactory {
     return {
       transaction: {
         type: type.toString(),
-        bytes: transaction.toBytes(),
+        bytes: this._encodeTransactionBytes(transaction),
       },
     };
   }
@@ -42,5 +42,10 @@ export class HederaParamsFactory {
     if (!nodeIds || nodeIds.length === 0) {
       transaction.setNodeAccountIds([new AccountId(3)]);
     }
+  }
+
+  private static _encodeTransactionBytes(transaction: Transaction): string {
+    const transactionBytes = transaction.toBytes();
+    return Buffer.from(transactionBytes).toString("base64");
   }
 }


### PR DESCRIPTION
### Summary
Encodes transaction bytes array as a base64 encoded string. This encoded string is then passed to the wallet as `params.transaction.bytes` value.

https://github.com/hgraph-io/hedera-walletconnect-dapp/assets/136644362/4696eb60-d459-419c-86c4-3878d5f4fd91

