### PR TITLE
Add test hedera_signAndReturnTransaction feature

### DIFF
--- a/src/constants/default.ts
+++ b/src/constants/default.ts
@@ -55,6 +55,7 @@ export enum DEFAULT_NEAR_EVENTS {}
  */
 export enum DEFAULT_HEDERA_METHODS {
   HEDERA_SIGN_AND_EXECUTE_TRANSACTION = "hedera_signAndExecuteTransaction",
+  HEDERA_SIGN_AND_RETURN_TRANSACTION = "hedera_signAndReturnTransaction",
 }
 
 export enum DEFAULT_HEDERA_EVENTS {}

--- a/src/contexts/JsonRpcContext.tsx
+++ b/src/contexts/JsonRpcContext.tsx
@@ -9,6 +9,7 @@ import {
   TransactionId,
   RequestType,
   TopicMessageSubmitTransaction,
+  Transaction,
 } from "@hashgraph/sdk";
 import {
   eip712,
@@ -529,7 +530,12 @@ export function JsonRpcContextProvider({
           method,
           address,
           valid: true,
-          result: JSON.stringify(result),
+          result: JSON.stringify({
+            raw: result,
+            decoded: Transaction.fromBytes(
+              Buffer.from((result as any).transaction.bytes, "base64")
+            ),
+          }),
         };
       }
     ),

--- a/src/helpers/HederaParamsFactory.ts
+++ b/src/helpers/HederaParamsFactory.ts
@@ -17,7 +17,7 @@ export type HederaSessionRequestParams =
   TypedRequestParams<HederaSignAndSendTransactionParams>;
 
 export class HederaParamsFactory {
-  public static buildSignAndSendTransactionPayload(
+  public static buildTransactionPayload(
     type: RequestType,
     transaction: Transaction
   ): HederaSignAndSendTransactionParams {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -171,28 +171,43 @@ const Home: NextPage = () => {
     return availableActions;
   };
 
-  const getHederaActions = (): AccountAction[] => {
-    const requestTypeHandlerMap = {
-      [RequestType.CryptoTransfer.toString()]:
-        hederaRpc.testSignAndSendCryptoTransfer,
-      [RequestType.ConsensusSubmitMessage.toString()]:
-        hederaRpc.testSignAndSendTopicSubmitMessage,
+  const openModalWithCallback =
+    (callback: keyof typeof hederaRpc) =>
+    async (chainId: string, address: string) => {
+      openRequestModal();
+      await hederaRpc[callback](chainId, address);
     };
-    const onSignAndSendTransaction =
-      (requestType: string) => async (chainId: string, address: string) => {
-        openRequestModal();
-        const transactionToExecute = requestTypeHandlerMap[requestType];
-        await transactionToExecute(chainId, address);
-      };
 
-    const actions: AccountAction[] = Object.keys(requestTypeHandlerMap).map(
-      (type) => ({
-        method:
-          DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_EXECUTE_TRANSACTION +
-          `: ${type.toString()}`,
-        callback: onSignAndSendTransaction(type.toString()),
-      })
-    );
+  const getHederaActions = (): AccountAction[] => {
+    const actions: AccountAction[] = [];
+
+    /** Sign and execute CryptoTransfer */
+    actions.push({
+      method:
+        DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_EXECUTE_TRANSACTION +
+        ": " +
+        RequestType.CryptoTransfer.toString(),
+      callback: openModalWithCallback("testSignAndExecuteCryptoTransfer"),
+    });
+
+    /** Sign and execute ConsensusSubmitMessage */
+    actions.push({
+      method:
+        DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_EXECUTE_TRANSACTION +
+        ": " +
+        RequestType.ConsensusSubmitMessage.toString(),
+      callback: openModalWithCallback("testSignAndExecuteTopicSubmitMessage"),
+    });
+
+    /** Sign and return CryptoTransfer */
+    actions.push({
+      method:
+        DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_RETURN_TRANSACTION +
+        ": " +
+        RequestType.CryptoTransfer.toString(),
+      callback: openModalWithCallback("testSignAndReturnCryptoTransfer"),
+    });
+
     return actions;
   };
 


### PR DESCRIPTION
### Summary
- Updates Hedera RPC context to build and send a transaction for signing and returning
- Adds basic display of raw signed transaction and decoded/reconstructed signed transaction

https://github.com/hgraph-io/hedera-walletconnect-dapp/assets/136644362/a3f3e7ab-645a-4a54-a191-bb9299293e42

